### PR TITLE
chore: Update Flutter version to 3.32.0 in CI workflow

### DIFF
--- a/.github/workflows/mvp.yml
+++ b/.github/workflows/mvp.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.29.2'
+        flutter-version: '3.32.0'
 
     # Create .env file
     - name: Create .env file


### PR DESCRIPTION
This pull request updates the Flutter version used in the GitHub Actions workflow to ensure compatibility with the latest features and improvements.

* [`.github/workflows/mvp.yml`](diffhunk://#diff-b22fcc2b60b64fd2b562a4dedd912e76cbd539b44ddabbc765757f2985030877L30-R30): Updated the `flutter-version` in the `Set up Flutter` step from `'3.29.2'` to `'3.32.0'`.